### PR TITLE
Update styles.css: sights-hover transform

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -554,7 +554,7 @@ strong {
   margin: 10px;
   padding: 20px;
   transition: all 0.5s ease;
-  transform: translateY(100%);
+  transform: translateY(110%);
   position: absolute;
   bottom: 0;
   right: 0;


### PR DESCRIPTION
Adjust .sights-hover Initial Position

    Increased the initial translateY value from 100% to 110% to position the .sights-hover element slightly further off the bottom of its parent. On smaller screens, sights-hover box what protruding from its hidden position.